### PR TITLE
Fix Arch mirror selection in image builds

### DIFF
--- a/distros/arch/image.yaml
+++ b/distros/arch/image.yaml
@@ -125,9 +125,12 @@ actions:
     pacman-key --init
     pacman-key --populate archlinux
 
-    # Fetch up-to-date HTTPS mirrors ranked by score, force-refresh package DBs
-    curl -fsSL "https://archlinux.org/mirrorlist/?country=all&protocol=https&use_mirror_status=on" \
-        | sed 's/^#Server/Server/' > /etc/pacman.d/mirrorlist
+    # Keep CI on a small stable mirror set. The full active global list can
+    # select slow mirrors and fail pacman's low-speed download timeout.
+    cat > /etc/pacman.d/mirrorlist <<'EOF'
+    Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch
+    Server = https://mirrors.kernel.org/archlinux/$repo/os/$arch
+    EOF
     pacman -Syy --noconfirm
 
 

--- a/distros/cachyos/image.yaml
+++ b/distros/cachyos/image.yaml
@@ -186,8 +186,12 @@ actions:
     # Enable #[multilib] / #Include block (\\\\ in YAML would break the sed address regex)
     sed -i '/^#\[multilib\]/,/^#Include/s/^#//' /etc/pacman.conf
 
-    curl -fsSL "https://archlinux.org/mirrorlist/?country=all&protocol=https&use_mirror_status=on" \
-      | sed 's/^#Server/Server/' > /etc/pacman.d/mirrorlist
+    # Keep CI on a small stable mirror set. The full active global list can
+    # select slow mirrors and fail pacman's low-speed download timeout.
+    cat > /etc/pacman.d/mirrorlist <<'EOF'
+    Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch
+    Server = https://mirrors.kernel.org/archlinux/$repo/os/$arch
+    EOF
 
     pacman -Syy --noconfirm
 


### PR DESCRIPTION
## Summary
- Use a small stable Arch mirror set in the Arch and CachyOS image recipes.
- Avoid slow mirror selection that can trigger pacman low-speed timeouts during image builds.

## Validation
- CachyOS image build completed successfully.
- GitHub Actions `Build Image (cachyos)` passed: https://github.com/ps5-linux/ps5-linux-image/actions/runs/26471204487