### PR TITLE
Include Kali in full image builds

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           INPUT="${{ inputs.distro || 'ubuntu2604' }}"
           if [ "$INPUT" = "all" ]; then
-            echo 'distros=["ubuntu2604","arch","cachyos"]' >> "$GITHUB_OUTPUT"
+            echo 'distros=["ubuntu2604","arch","cachyos","kali"]' >> "$GITHUB_OUTPUT"
           else
             echo "distros=[\"$INPUT\"]" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Summary
- Include Kali in the `all` image build matrix.
- This makes the default deploy workflow build Kali alongside Ubuntu 26.04, Arch, and CachyOS.

## Validation
- Workflow YAML parses successfully.