### PR TITLE
fix: export CHROOT to per-distro build-rootfs.sh

### DIFF
--- a/distros/batocera/build-rootfs.sh
+++ b/distros/batocera/build-rootfs.sh
@@ -13,6 +13,10 @@
 
 set -ex
 
+: "${CHROOT:?ERROR: \$CHROOT unset/empty}"
+[ -d "$CHROOT" ] || { echo "ERROR: \$CHROOT=$CHROOT not a directory"; exit 2; }
+case "$CHROOT" in /) echo "ERROR: refuse to operate on /"; exit 2 ;; esac
+
 # Batocera is a Buildroot-based emulation distro. It ships as a
 # single .img.gz with FAT32 boot + ext4 SHARE partitions; the OS
 # itself lives in a squashfs file (`/boot/batocera`) on the FAT32.

--- a/distros/bazzite/build-rootfs.sh
+++ b/distros/bazzite/build-rootfs.sh
@@ -11,6 +11,10 @@
 
 set -ex
 
+: "${CHROOT:?ERROR: \$CHROOT unset/empty}"
+[ -d "$CHROOT" ] || { echo "ERROR: \$CHROOT=$CHROOT not a directory"; exit 2; }
+case "$CHROOT" in /) echo "ERROR: refuse to operate on /"; exit 2 ;; esac
+
 # Bazzite is an OCI atomic image; bypass distrobuilder entirely.
 # DISTRO=bazzite      -> ghcr.io/ublue-os/bazzite:stable
 # DISTRO=bazzite-deck -> ghcr.io/ublue-os/bazzite-deck:stable

--- a/docker/image-builder/entrypoint.sh
+++ b/docker/image-builder/entrypoint.sh
@@ -32,8 +32,12 @@ elif [ -x "/repo/distros/${DISTRO}/build-rootfs.sh" ]; then
     # bypassed entirely. Most often used for OCI atomic images (bazzite via
     # skopeo+umoci) or pre-built rootfs images (batocera squashfs).
     echo "=== Building $DISTRO rootfs via distros/${DISTRO}/build-rootfs.sh ==="
+    [ -n "$CHROOT" ] || { echo "FATAL: \$CHROOT empty"; exit 1; }
+    mkdir -p "$CHROOT"
     rm -rf "$CHROOT"/* "$CHROOT"/.[!.]* 2>/dev/null || true
-    bash "/repo/distros/${DISTRO}/build-rootfs.sh"
+    DISTRO="$DISTRO" CHROOT="$CHROOT" KVER="$KVER" \
+        ROOT_LABEL="$ROOT_LABEL" EFI_LABEL="$EFI_LABEL" \
+        bash "/repo/distros/${DISTRO}/build-rootfs.sh"
 else
     echo "=== Building $DISTRO rootfs ==="
     # --- Stage files for distrobuilder's copy generators ---


### PR DESCRIPTION
Without it the script saw empty $CHROOT and tried to mv the bazzite OCI rootfs into '/'. Adds a top-of-script guard too.