### PR TITLE
build_image: include .rpm in --distro all output

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -335,7 +335,7 @@ else
                 ps5-kernel-packager-arch
     esac
 
-    case "$FORMAT" in rpm)
+    case "$FORMAT" in rpm|all)
         run_stage "Build rpm packager image" \
             docker build -t ps5-kernel-packager-rpm \
                 -f "$SCRIPT_DIR/docker/kernel-builder-rpm/Dockerfile" "$SCRIPT_DIR"


### PR DESCRIPTION
The rpm packager case only fired when `FORMAT=rpm`, so `--distro all` produced only `.deb` and `.pkg.tar.zst`. That leaves Fedora / Bazzite users out of the ps5-linux-patches release artifacts and forces a downstream `alien`/`rpmbuild` step in the mirror. Include rpm in the all-format switch so a single kernel build produces all three formats at once.

Paired with a follow-up PR to `ps5-linux/ps5-linux-patches` that updates `build-kernel.yml` to upload/release the .rpm alongside the existing artifacts.