### PR TITLE
Skip rootfs auto-grow on M2

### DIFF
--- a/distros/arch/grow-rootfs
+++ b/distros/arch/grow-rootfs
@@ -12,6 +12,16 @@ set -e
 
 ROOT_DEV=$(findmnt -no SOURCE /)
 DISK="/dev/$(lsblk -ndo PKNAME "$ROOT_DEV")"
+
+# PS5 M.2 drive appear as /dev/nvme*. Do not modify partition table,
+# because it contains m2_init PS5 offset. Only USB drive (/dev/sd*)
+# are safe for automatic grow root partition.
+if [[ "$(basename "$DISK")" == nvme* ]]; then
+    echo "grow-rootfs: M.2 detected, skipping"
+    systemctl disable grow-rootfs.service
+    exit 0
+fi
+
 PART_NUM=$(cat /sys/class/block/$(basename "$ROOT_DEV")/partition)
 
 # Our images dd at their built size (~14 GB) onto a much larger USB. The GPT


### PR DESCRIPTION
Updates the `distros/arch/grow-rootfs` script to add a safety check for PS5 M.2 drives. The script now detects if the root filesystem is on an M.2 NVMe drive and skips resizing operations to avoid corrupting the special partition layout created with `m2_init`.